### PR TITLE
Fix tiny typo in documentation

### DIFF
--- a/lib/Email/MessageID.pm
+++ b/lib/Email/MessageID.pm
@@ -11,7 +11,7 @@ use overload '""' => 'as_string', fallback => 1;
 
   my $mid = Email::MessageID->new->in_brackets;
 
-  print "Message-ID: $mid\x0A\x0D";
+  print "Message-ID: $mid\x0D\x0A";
 
 =head1 DESCRIPTION
 


### PR DESCRIPTION
The SMTP line ending is 0x0D 0x0A (aka CR LF), not the other way round.